### PR TITLE
fix: Move friendbot URL fetch outside vite config

### DIFF
--- a/src/components/FundAccountButton.tsx
+++ b/src/components/FundAccountButton.tsx
@@ -2,6 +2,7 @@ import React, { useState, useTransition } from 'react';
 import { useNotification } from '../hooks/useNotification.ts';
 import { useWallet } from '../hooks/useWallet.ts';
 import { Button, Tooltip } from '@stellar/design-system';
+import { getFriendbotUrl } from '../util/friendbot';
 
 
 const FundAccountButton: React.FC = () => {
@@ -14,7 +15,7 @@ const FundAccountButton: React.FC = () => {
   const handleFundAccount = (account: string) => {
     startTransition(async () => {
       try {
-        const response = await fetch(`/friendbot?addr=${account}`, {
+        const response = await fetch(getFriendbotUrl(account), {
           method: 'GET',
         });
 

--- a/src/util/friendbot.ts
+++ b/src/util/friendbot.ts
@@ -1,0 +1,17 @@
+import { stellarNetwork } from "../contracts/util";
+
+// Utility to get the correct Friendbot URL based on environment
+export function getFriendbotUrl(address: string) {
+    if (stellarNetwork === "local") {
+        // Use proxy in development for local
+        return `/friendbot?addr=${address}`;
+    }
+    switch (stellarNetwork) {
+        case "futurenet":
+            return `https://friendbot-futurenet.stellar.org/?addr=${address}`;
+        case "testnet":
+            return `https://friendbot.stellar.org/?addr=${address}`;
+        default:
+            throw new Error(`Unknown or unsupported PUBLIC_STELLAR_NETWORK for friendbot: ${stellarNetwork}`);
+    }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,27 +1,8 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-function getFriendbotHost(mode: string) {
-  // See https://developers.stellar.org/docs/tools/quickstart/faucet for more information
-  // on friendbot and the local faucet
-  const env = loadEnv(mode, process.cwd(), '')
-  switch (env.PUBLIC_STELLAR_NETWORK) {
-    case "local":
-      return "http://localhost:8000/friendbot";
-    case "futurenet":
-      return "https://friendbot-futurenet.stellar.org";
-    case "testnet":
-      return "https://friendbot.stellar.org";
-    case "mainnet":
-      // friendbot is not available on mainnet, this is a fallback that should not need to be called
-      return "https://friendbot.stellar.org";
-    default:
-      throw new Error(`Unknown PUBLIC_STELLAR_NETWORK: ${env.PUBLIC_STELLAR_NETWORK}`);
-  }
-}
-
 // https://vite.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(() => {
   return {
     plugins: [react()],
     define: {
@@ -31,9 +12,8 @@ export default defineConfig(({ mode }) => {
     server: {
       proxy: {
         '/friendbot': {
-          target: getFriendbotHost(mode),
+          target: 'http://localhost:8000/friendbot',
           changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/friendbot/, ''),
         },
       }
     }


### PR DESCRIPTION
The proxy server setting is cool, but since we want people to be able to deploy this app/frontend to static builds, we can't rely on that. Move the friendbot setting outside the vite config.