### PR TITLE
fix: hide balance error

### DIFF
--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -26,8 +26,8 @@ export const WalletButton = () => {
   }
 
   const showTooltip = () => {
-    if (balance.error) return;
     void balance.updateBalance();
+    if (balance.error) return;
     setIsTooltipVisible(true);
   };
 


### PR DESCRIPTION
<img width="484" alt="Screenshot 2025-06-05 at 10 04 42 AM" src="https://github.com/user-attachments/assets/bd862aa4-5231-4fa4-b1d3-6d46ee336a71" />

A bit of a hotfix/hopefully temporary patch, don't show the tooltip that has the account balance if we errored trying to fetch it… in theory I could argue this makes showing the account balance a progressive enhancement. But will unblock making a demo video.