### PR TITLE
fix: race condition with docker container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libudev-dev libdbus-1-dev pkg-config
       # Install binstall to quickly install stellar-scaffold-cli
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.15.6
+        uses: cargo-bins/cargo-binstall@main
       # Check for stellar-scaffold-cli binary and install if not present
       - name: Check for stellar-scaffold binary
         run: |


### PR DESCRIPTION
The `stellar/quickstart` action seems to be redundant since `stellar-scaffold` commands will start the container if it isn't previously running. Having both actions in the workflow seems to be causing errors. My best guess is that the quickstart action runs and waits till the service is healthy, but then the scaffold build command tries to restart it before checking the health endpoint, which cancels the health check and fails the action ([example](https://github.com/theahaco/scaffold-stellar-frontend/actions/runs/18749824360/job/53486143537)).