### PR TITLE
feat: stop vite on scaffold exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"stellar scaffold watch --build-clients\" \"vite\"",
-    "start": "concurrently \"stellar scaffold watch --build-clients\" \"vite\"",
+    "dev": "npm start",
+    "start": "concurrently --kill-others-on-fail --names stellar,vite -c gray,green --pad-prefix \"stellar scaffold watch --build-clients\" \"vite\"",
     "build": "tsc -b && vite build",
     "install:contracts": "npm install --workspace=packages && npm run build --workspace=packages",
     "preview": "vite preview",


### PR DESCRIPTION
Configure `concurrently` to stop when either process exits with an error code. Fixes https://github.com/theahaco/scaffold-stellar/issues/288

Also add helpful color coded names instead of looking for generic `[0]` and `[1]` default prefixes based on command order.