### PR TITLE
build/deps: Configure cooldown for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       npm-minor:
         update-types:


### PR DESCRIPTION
Inspired by some recent supply chain situations, implement a [cooldown](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) for dependabot upgrades.

https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns