### PR TITLE
Update soroban-sdk version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/theahaco/scaffold-stellar"
 version = "0.0.1"
 
 [workspace.dependencies.soroban-sdk]
-version = "23.1.0"
+version = "23.4.0"
 
 [workspace.dependencies.stellar-access]
 git = "https://github.com/OpenZeppelin/stellar-contracts"

--- a/contracts/guess-the-number/Cargo.toml
+++ b/contracts/guess-the-number/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = {workspace = true}
+soroban-sdk = "23.0.3"
 stellar-registry = "0.0.4"
 
 [dev-dependencies]
 stellar-xdr = { version = "23.0.0", features = ["curr", "serde"] }
-soroban-sdk = { workspace=true, features = ["testutils"] }
+soroban-sdk = { version = "23.0.3", features = ["testutils"] }

--- a/contracts/guess-the-number/Cargo.toml
+++ b/contracts/guess-the-number/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "23.0.3"
+soroban-sdk = {workspace = true}
 stellar-registry = "0.0.4"
 
 [dev-dependencies]
 stellar-xdr = { version = "23.0.0", features = ["curr", "serde"] }
-soroban-sdk = { version = "23.0.3", features = ["testutils"] }
+soroban-sdk = { workspace=true, features = ["testutils"] }


### PR DESCRIPTION
Short term fix for https://github.com/theahaco/scaffold-stellar/issues/356

We're seeing a mismatch between the sdk version that we're specifying in this workspace vs the version that is being 
specified in the latest release of the oz contracts.

Medium/long term, we should make sure we're able to prevent `stellar scaffold init` from failing if the oz contracts are updated before we update the dependencies. Still thinking this through, and will make sure to put some more info in the issue.

To repo the error:

```
> stellar scaffold init test-scaffold-project-1

...
⚠️ Failed to build contract clients: `cargo metadata` exited with an error:     Updating git repository `https://github.com/OpenZeppelin/stellar-contracts`
    Updating crates.io index
error: failed to select a version for `soroban-sdk`.
    ... required by package `stellar-access v0.6.0 (https://github.com/OpenZeppelin/stellar-contracts?tag=v0.6.0#82f97111)`
    ... which satisfies git dependency `stellar-access` of package `fungible-allowlist-example v0.0.1 (/Users/ebethme/Desktop/projects/tutorials/scaffold-init-test-4/contracts/fungible-allowlist)`
versions that meet the requirements `^23.4.0` are: 23.4.1, 23.4.0

all possible versions conflict with previously selected packages.

  previously selected package `soroban-sdk v23.1.0`
    ... which satisfies dependency `soroban-sdk = "^23.1.0"` (locked to 23.1.0) of package `fungible-allowlist-example v0.0.1 (/Users/ebethme/Desktop/projects/tutorials/scaffold-init-test-4/contracts/fungible-allowlist)`

failed to select a version for `soroban-sdk` which could resolve this conflict
...

```

To test this branch:

```
> stellar scaffold init test-scaffold-project-2 --tag upgrade-soroban-sdk

```