### PR TITLE
Add stellar-contract-utils to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ tag = "v0.5.1"
 git = "https://github.com/OpenZeppelin/stellar-contracts"
 tag = "v0.5.1"
 
+[workspace.dependencies.stellar-contract-utils]
+git = "https://github.com/OpenZeppelin/stellar-contract-utils"
+tag = "v0.5.1"
+
 [profile.release]
 opt-level = "z"
 debug = false


### PR DESCRIPTION
This PR adds `stellar-contract-utils` as a dependency in Cargo.toml, which will allow several more OZ examples to build from a fresh scaffold project:
- oz/fungible-merkle-airdrop
- oz/fungible-pausable
- oz/pausable

At the moment, these if you generate with these examples, it will produce this error on build:
```
error: `cargo metadata` exited with an error: error: failed to load manifest for workspace member `/Users/ebethme/Desktop/projects/stellar/test-projects/ee-test-130-d/contracts/fungible-pausable`
referenced via `contracts/*` by workspace at `/Users/ebethme/Desktop/projects/stellar/test-projects/ee-test-130-d/Cargo.toml`

Caused by:
  failed to parse manifest at `/Users/ebethme/Desktop/projects/stellar/test-projects/ee-test-130-d/contracts/fungible-pausable/Cargo.toml`

Caused by:
  error inheriting `stellar-contract-utils` from workspace root manifest's `workspace.dependencies.stellar-contract-utils`

Caused by:
  `dependency.stellar-contract-utils` was not found in `workspace.dependencies`

```