### PR TITLE
fix: stabilize quickstart on OZ v0.6.0 — deps, contract code, and constructor args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,19 @@ repository = "https://github.com/theahaco/scaffold-stellar"
 version = "0.0.1"
 
 [workspace.dependencies.soroban-sdk]
-version = "23.1.0"
+version = "23.4.0"
 
 [workspace.dependencies.stellar-access]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.5.1"
+tag = "v0.6.0"
 
 [workspace.dependencies.stellar-macros]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.5.1"
+tag = "v0.6.0"
 
 [workspace.dependencies.stellar-tokens]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.5.1"
+tag = "v0.6.0"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/fungible-allowlist/src/contract.rs
+++ b/contracts/fungible-allowlist/src/contract.rs
@@ -5,9 +5,11 @@
 //! controlled token transfers by an admin who can allow or disallow specific
 //! accounts.
 
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, Address, Env, MuxedAddress, String, Symbol, Vec,
+};
 use stellar_access::access_control::{self as access_control, AccessControl};
-use stellar_macros::{default_impl, only_role};
+use stellar_macros::only_role;
 use stellar_tokens::fungible::{
     allowlist::{AllowList, FungibleAllowList},
     burnable::FungibleBurnable,
@@ -19,18 +21,20 @@ pub struct ExampleContract;
 
 #[contractimpl]
 impl ExampleContract {
-    pub fn __constructor(e: &Env, admin: Address, manager: Address, initial_supply: i128) {
-        Base::set_metadata(
-            e,
-            18,
-            String::from_str(e, "AllowList Token"),
-            String::from_str(e, "ALT"),
-        );
+    pub fn __constructor(
+        e: &Env,
+        name: String,
+        symbol: String,
+        admin: Address,
+        manager: Address,
+        initial_supply: i128,
+    ) {
+        Base::set_metadata(e, 18, name, symbol);
 
         access_control::set_admin(e, &admin);
 
         // create a role "manager" and grant it to `manager`
-        access_control::grant_role_no_auth(e, &admin, &manager, &symbol_short!("manager"));
+        access_control::grant_role_no_auth(e, &manager, &admin, &symbol_short!("manager"));
 
         // Allow the admin to transfer tokens
         AllowList::allow_user(e, &admin);
@@ -40,8 +44,7 @@ impl ExampleContract {
     }
 }
 
-#[default_impl]
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl FungibleToken for ExampleContract {
     type ContractType = AllowList;
 }
@@ -62,10 +65,8 @@ impl FungibleAllowList for ExampleContract {
     }
 }
 
-#[default_impl]
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl AccessControl for ExampleContract {}
 
-#[default_impl]
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl FungibleBurnable for ExampleContract {}

--- a/contracts/fungible-allowlist/src/contract.rs
+++ b/contracts/fungible-allowlist/src/contract.rs
@@ -34,7 +34,7 @@ impl ExampleContract {
         access_control::set_admin(e, &admin);
 
         // create a role "manager" and grant it to `manager`
-        access_control::grant_role_no_auth(e, &manager, &admin, &symbol_short!("manager"));
+        access_control::grant_role_no_auth(e, &manager, &symbol_short!("manager"), &admin);
 
         // Allow the admin to transfer tokens
         AllowList::allow_user(e, &admin);

--- a/contracts/nft-enumerable/src/contract.rs
+++ b/contracts/nft-enumerable/src/contract.rs
@@ -5,7 +5,6 @@
 //! IDs owned by each account.
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
-use stellar_macros::default_impl;
 use stellar_tokens::non_fungible::{
     burnable::NonFungibleBurnable,
     enumerable::{Enumerable, NonFungibleEnumerable},
@@ -22,14 +21,9 @@ pub struct ExampleContract;
 
 #[contractimpl]
 impl ExampleContract {
-    pub fn __constructor(e: &Env, owner: Address) {
+    pub fn __constructor(e: &Env, uri: String, name: String, symbol: String, owner: Address) {
         e.storage().instance().set(&DataKey::Owner, &owner);
-        Base::set_metadata(
-            e,
-            String::from_str(e, "www.mytoken.com"),
-            String::from_str(e, "My Token"),
-            String::from_str(e, "TKN"),
-        );
+        Base::set_metadata(e, uri, name, symbol);
     }
 
     pub fn mint(e: &Env, to: Address) -> u32 {
@@ -40,16 +34,13 @@ impl ExampleContract {
     }
 }
 
-#[default_impl]
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl NonFungibleToken for ExampleContract {
     type ContractType = Enumerable;
 }
 
-#[default_impl]
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl NonFungibleEnumerable for ExampleContract {}
 
-#[default_impl]
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl NonFungibleBurnable for ExampleContract {}

--- a/environments.toml
+++ b/environments.toml
@@ -9,8 +9,8 @@ name = "me" # Required. Keys for this account will be saved to `./.stellar/ident
 default = true # Optional. Whether to use this account as the `--source` for commands that need one.
 
 [development.contracts]
-fungible_allowlist_example = { client = true, constructor_args = "--admin me --manager me --initial_supply 1000000000000000000000000" }
-nft_enumerable_example = { client = true, constructor_args = "--owner me" }
+fungible_allowlist_example = { client = true, constructor_args = "--name ExampleToken --symbol EXT --admin me --manager me --initial_supply 1000000000000000000000000" }
+nft_enumerable_example = { client = true, constructor_args = "--uri https://example.com/nft/ --name ExampleNFT --symbol ENFT --owner me" }
 
 # Rather than in one list, TOML allows specifying contracts in their own "sections"
 [development.contracts.guess_the_number]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "npm start",
     "start": "concurrently --kill-others-on-fail --names stellar,vite -c gray,green --pad-prefix \"stellar scaffold watch --build-clients\" \"vite\"",
     "build": "tsc -b && vite build",
-    "install:contracts": "npm install --workspace=packages && npm run build --workspace=packages",
+    "install:contracts": "npm install --workspaces && npm run build --workspaces",
     "preview": "vite preview",
     "lint": "eslint .",
     "format": "prettier . --write",


### PR DESCRIPTION
## Problem

The quickstart is broken. Running `stellar scaffold init` + `npm run dev` fails for 2 of 3 example contracts (`fungible-allowlist` and `nft-enumerable`). There are three compounding issues:

1. **Dep version mismatch:** `Cargo.toml` pins OZ crates to `v0.5.1` and soroban-sdk to `23.1.0`, but OZ v0.6.0 requires `soroban-sdk ^23.4.0`. The CLI (after [theahaco/scaffold-stellar#451](https://github.com/theahaco/scaffold-stellar/pull/451)) pulls v0.6.0 examples, which fail to resolve against the template's pinned deps.

2. **Contract code uses v0.7.x syntax:** The contract source on main was updated to use `#[default_impl]` (OZ v0.7.x), but the deps were never bumped to match — so `stellar_macros::default_impl` doesn't exist and compilation fails regardless of this PR.

3. **Missing constructor args:** `fungible_allowlist_example` is missing `--name` and `--symbol`. `nft_enumerable_example` is missing `--uri`, `--name`, and `--symbol`. Client generation fails with `Missing required argument`.

Additionally, the `install:contracts` script in `package.json` uses `--workspace=packages` (targeting a workspace *named* "packages" which doesn't exist) instead of `--workspaces` (targeting all workspaces). This causes CI failures.

## What this PR does

Stabilizes everything on **OZ v0.6.0** (the latest stable release that works with soroban-sdk 23.x):

### Change 1: Bump deps to v0.6.0 (`Cargo.toml`)
- `soroban-sdk`: `23.1.0` → `23.4.0`
- `stellar-access`, `stellar-macros`, `stellar-tokens`: `v0.5.1` → `v0.6.0`

### Change 2: Revert contract code to v0.6.0 syntax
- Replace `#[default_impl]` + `#[contractimpl]` with `#[contractimpl(contracttrait)]` (v0.6.0 API)
- Remove `stellar_macros::default_impl` imports
- Accept `name`/`symbol`/`uri` as constructor params instead of hardcoding them
- Fix `grant_role_no_auth` argument order for v0.6.0 API

### Change 3: Add missing constructor args (`environments.toml`)
- `fungible_allowlist_example`: add `--name ExampleToken --symbol EXT`
- `nft_enumerable_example`: add `--uri https://example.com/nft/ --name ExampleNFT --symbol ENFT`

### Change 4: Fix `install:contracts` script (`package.json`)
- `--workspace=packages` → `--workspaces` (plural, targets all workspaces)

## v0.7.x upgrade path

This PR intentionally targets v0.6.0 to unblock the quickstart now. OZ [v0.7.0](https://github.com/OpenZeppelin/stellar-contracts/releases/tag/v0.7.0) (stable Apr 3) and [v0.7.1](https://github.com/OpenZeppelin/stellar-contracts/releases/tag/v0.7.1) (Apr 10) require soroban-sdk 25.x, which is a larger upgrade. The contract code for v0.7.x is already written — a follow-up PR just needs to bump `Cargo.toml` to soroban-sdk 25.x + OZ v0.7.x and revert the macro syntax back to `#[default_impl]`.

## Test plan

- [x] Fresh `stellar scaffold init` + `npm run dev` builds, deploys, and generates clients for all 3 contracts with zero errors
- [x] Client Generation Summary: Successfully processed: 3, Failed: 0
- [x] Contract Explorer at `/debug` works for all 3 contracts

Companion to [theahaco/scaffold-stellar#451](https://github.com/theahaco/scaffold-stellar/pull/451) (merged).
Closes [theahaco/scaffold-stellar#450](https://github.com/theahaco/scaffold-stellar/issues/450).
Addresses [theahaco/scaffold-stellar#370](https://github.com/theahaco/scaffold-stellar/issues/370).
