### PR TITLE
Support all wallet modules

### DIFF
--- a/src/components/WalletButton.module.css
+++ b/src/components/WalletButton.module.css
@@ -1,6 +1,23 @@
 /* Override the global a[target]::after external 
 link icon that appeared on the warning sign */
-a.warningIcon[target]::after {
+.learnMore[target]::after {
 	content: none;
 	display: none;
+}
+.learnMore {
+	color: var(--sds-clr-lilac-09, #606);
+}
+
+.warningIcon {
+	height: 20px;
+	width: 20px;
+	color: var(--color-yellow-60, #f0ad4e);
+	position: absolute;
+	bottom: -8px;
+	right: -8px;
+	cursor: pointer;
+}
+
+.profileWrap {
+	position: relative;
 }

--- a/src/components/WalletButton.module.css
+++ b/src/components/WalletButton.module.css
@@ -1,0 +1,6 @@
+/* Override the global a[target]::after external 
+link icon that appeared on the warning sign */
+a.warningIcon[target]::after {
+	content: none;
+	display: none;
+}

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -13,23 +13,8 @@ import cssStyles from "./WalletButton.module.css"
 
 export const WalletButton = () => {
 	const [showDisconnectModal, setShowDisconnectModal] = useState(false)
-	const [isWarningTooltipVisible, setIsWarningTooltipVisible] = useState(false)
 	const { address, isPending, balances, walletWarnings } = useWallet()
 	const buttonLabel = isPending ? "Loading..." : "Connect"
-
-	const warningIconStyles = {
-		display: "flex",
-		alignItems: "center",
-		justifyContent: "center",
-		overflow: "hidden",
-		backgroundColor: "var(--color-gray-00, #fff)",
-		borderRadius: "50%",
-		padding: "3px",
-		border: "2px solid var(--color-yellow-60, #f0ad4e)",
-		boxShadow: "0 1px 3px rgba(0, 0, 0, 0.2)",
-		lineHeight: 0,
-		textDecoration: "none",
-	} as const
 
 	if (!address) {
 		return (
@@ -109,7 +94,7 @@ export const WalletButton = () => {
 				</Modal>
 			</div>
 
-			<div style={{ position: "relative" }}>
+			<div className={cssStyles.profileWrap}>
 				<Profile
 					publicAddress={address}
 					size="md"
@@ -118,45 +103,23 @@ export const WalletButton = () => {
 				/>
 
 				{walletWarnings.hasWarnings && (
-					<div
-						onMouseEnter={() => setIsWarningTooltipVisible(true)}
-						onMouseLeave={() => setIsWarningTooltipVisible(false)}
-						style={{
-							position: "absolute",
-							top: "-6px",
-							right: "-6px",
-							zIndex: 1,
-						}}
+					<Tooltip
+						placement="bottom"
+						triggerEl={<Icon.AlertTriangle className={cssStyles.warningIcon} />}
 					>
-						<Tooltip
-							isVisible={isWarningTooltipVisible}
-							isContrast
-							placement="bottom"
-							triggerEl={React.createElement(
-								walletWarnings.helpUrl ? "a" : "span",
-								walletWarnings.helpUrl
-									? {
-											href: walletWarnings.helpUrl,
-											target: "_blank",
-											className: cssStyles.warningIcon,
-											style: warningIconStyles,
-										}
-									: { style: warningIconStyles },
-								<Icon.AlertTriangle
-									style={{
-										color: "var(--color-yellow-60, #f0ad4e)",
-										width: "12px",
-										height: "12px",
-									}}
-								/>,
+						<div style={{ maxWidth: "15em" }}>
+							{walletWarnings.messages.join("")}
+							{walletWarnings.helpUrl && (
+								<a
+									className={cssStyles.learnMore}
+									href={walletWarnings.helpUrl}
+									target="_blank"
+								>
+									Learn more
+								</a>
 							)}
-						>
-							<div style={{ maxWidth: "15em" }}>
-								{walletWarnings.messages.join(". ")}
-								{walletWarnings.helpUrl ? ". Click to learn more." : ""}
-							</div>
-						</Tooltip>
-					</div>
+						</div>
+					</Tooltip>
 				)}
 			</div>
 		</div>

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -17,18 +17,6 @@ export const WalletButton = () => {
 	const { address, isPending, balances, walletWarnings } = useWallet()
 	const buttonLabel = isPending ? "Loading..." : "Connect"
 
-	// Build warning message based on wallet issues
-	const getWarningMessage = () => {
-		const warnings: string[] = []
-		if (walletWarnings.popupAlways) {
-			warnings.push("This wallet triggers a popup on every interaction")
-		}
-		if (walletWarnings.noGetNetworkSupport) {
-			warnings.push("This wallet doesn't support network detection")
-		}
-		return warnings.join(". ")
-	}
-
 	const warningIconStyles = {
 		display: "flex",
 		alignItems: "center",
@@ -164,7 +152,7 @@ export const WalletButton = () => {
 							)}
 						>
 							<div style={{ maxWidth: "15em" }}>
-								{getWarningMessage()}
+								{walletWarnings.messages.join(". ")}
 								{walletWarnings.helpUrl ? ". Click to learn more." : ""}
 							</div>
 						</Tooltip>

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -65,9 +65,27 @@ export const WalletButton = () => {
 				>
 					<Modal.Heading>Disconnect wallet?</Modal.Heading>
 					<Modal.Body>
-						<Text as="p" size="sm">
-							Connected as{" "}
-							<code>{`${address.slice(0, 6)}...${address.slice(-6)}`}</code>
+						<Text
+							as="div"
+							size="sm"
+							style={{
+								display: "flex",
+								alignItems: "baseline",
+								minWidth: 0,
+							}}
+						>
+							<span style={{ flexShrink: 0 }}>Connected as&nbsp;</span>
+							<code
+								style={{
+									overflow: "hidden",
+									textOverflow: "ellipsis",
+									whiteSpace: "nowrap",
+									fontSize: "0.85em",
+								}}
+								title={address}
+							>
+								{address}
+							</code>
 						</Text>
 					</Modal.Body>
 					<Modal.Footer itemAlignment="stack">

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -6,9 +6,10 @@ import {
 	Icon,
 	Tooltip,
 } from "@stellar/design-system"
-import { useState } from "react"
+import React, { useState } from "react"
 import { useWallet } from "../hooks/useWallet"
 import { connectWallet, disconnectWallet } from "../util/wallet"
+import cssStyles from "./WalletButton.module.css"
 
 export const WalletButton = () => {
 	const [showDisconnectModal, setShowDisconnectModal] = useState(false)
@@ -28,12 +29,19 @@ export const WalletButton = () => {
 		return warnings.join(". ")
 	}
 
-	// Handle click on warning icon - open help URL if available
-	const handleWarningClick = () => {
-		if (walletWarnings.helpUrl) {
-			window.open(walletWarnings.helpUrl, "_blank", "noopener,noreferrer")
-		}
-	}
+	const warningIconStyles = {
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		overflow: "hidden",
+		backgroundColor: "var(--color-gray-00, #fff)",
+		borderRadius: "50%",
+		padding: "3px",
+		border: "2px solid var(--color-yellow-60, #f0ad4e)",
+		boxShadow: "0 1px 3px rgba(0, 0, 0, 0.2)",
+		lineHeight: 0,
+		textDecoration: "none",
+	} as const
 
 	if (!address) {
 		return (
@@ -136,33 +144,28 @@ export const WalletButton = () => {
 							isVisible={isWarningTooltipVisible}
 							isContrast
 							placement="bottom"
-							triggerEl={
-								<div
-									onClick={handleWarningClick}
+							triggerEl={React.createElement(
+								walletWarnings.helpUrl ? "a" : "span",
+								walletWarnings.helpUrl
+									? {
+											href: walletWarnings.helpUrl,
+											target: "_blank",
+											className: cssStyles.warningIcon,
+											style: warningIconStyles,
+										}
+									: { style: warningIconStyles },
+								<Icon.AlertTriangle
 									style={{
-										display: "flex",
-										alignItems: "center",
-										justifyContent: "center",
-										cursor: "pointer",
-										backgroundColor: "var(--color-gray-00, #fff)",
-										borderRadius: "50%",
-										padding: "3px",
-										border: "2px solid var(--color-yellow-60, #f0ad4e)",
-										boxShadow: "0 1px 3px rgba(0, 0, 0, 0.2)",
+										color: "var(--color-yellow-60, #f0ad4e)",
+										width: "12px",
+										height: "12px",
 									}}
-								>
-									<Icon.AlertTriangle
-										style={{
-											color: "var(--color-yellow-60, #f0ad4e)",
-											width: "12px",
-											height: "12px",
-										}}
-									/>
-								</div>
-							}
+								/>,
+							)}
 						>
 							<div style={{ maxWidth: "15em" }}>
-								{getWarningMessage()}. Click to learn more about this issue.
+								{getWarningMessage()}
+								{walletWarnings.helpUrl ? ". Click to learn more." : ""}
 							</div>
 						</Tooltip>
 					</div>

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -1,21 +1,43 @@
-import { Button, Icon, Text, Modal, Profile } from "@stellar/design-system"
+import {
+	Button,
+	Text,
+	Modal,
+	Profile,
+	Icon,
+	Tooltip,
+} from "@stellar/design-system"
 import { useState } from "react"
 import { useWallet } from "../hooks/useWallet"
 import { connectWallet, disconnectWallet } from "../util/wallet"
 
 export const WalletButton = () => {
 	const [showDisconnectModal, setShowDisconnectModal] = useState(false)
-	const { address, isPending, balances } = useWallet()
-	const buttonLabel = isPending ? "Loading..." : "Connect Wallet"
+	const [isWarningTooltipVisible, setIsWarningTooltipVisible] = useState(false)
+	const { address, isPending, balances, walletWarnings } = useWallet()
+	const buttonLabel = isPending ? "Loading..." : "Connect"
+
+	// Build warning message based on wallet issues
+	const getWarningMessage = () => {
+		const warnings: string[] = []
+		if (walletWarnings.popupAlways) {
+			warnings.push("This wallet triggers a popup on every interaction")
+		}
+		if (walletWarnings.noGetNetworkSupport) {
+			warnings.push("This wallet doesn't support network detection")
+		}
+		return warnings.join(". ")
+	}
+
+	// Handle click on warning icon - open help URL if available
+	const handleWarningClick = () => {
+		if (walletWarnings.helpUrl) {
+			window.open(walletWarnings.helpUrl, "_blank", "noopener,noreferrer")
+		}
+	}
 
 	if (!address) {
 		return (
-			<Button
-				variant="secondary"
-				size="md"
-				onClick={() => void connectWallet()}
-			>
-				<Icon.Wallet02 />
+			<Button variant="primary" size="md" onClick={() => void connectWallet()}>
 				{buttonLabel}
 			</Button>
 		)
@@ -41,11 +63,13 @@ export const WalletButton = () => {
 					onClose={() => setShowDisconnectModal(false)}
 					parentId="modalContainer"
 				>
-					<Modal.Heading>
-						Connected as{" "}
-						<code style={{ lineBreak: "anywhere" }}>{address}</code>. Do you
-						want to disconnect?
-					</Modal.Heading>
+					<Modal.Heading>Disconnect wallet?</Modal.Heading>
+					<Modal.Body>
+						<Text as="p" size="sm">
+							Connected as{" "}
+							<code>{`${address.slice(0, 6)}...${address.slice(-6)}`}</code>
+						</Text>
+					</Modal.Body>
 					<Modal.Footer itemAlignment="stack">
 						<Button
 							size="md"
@@ -71,12 +95,61 @@ export const WalletButton = () => {
 				</Modal>
 			</div>
 
-			<Profile
-				publicAddress={address}
-				size="md"
-				isShort
-				onClick={() => setShowDisconnectModal(true)}
-			/>
+			<div style={{ position: "relative" }}>
+				<Profile
+					publicAddress={address}
+					size="md"
+					isShort
+					onClick={() => setShowDisconnectModal(true)}
+				/>
+
+				{walletWarnings.hasWarnings && (
+					<div
+						onMouseEnter={() => setIsWarningTooltipVisible(true)}
+						onMouseLeave={() => setIsWarningTooltipVisible(false)}
+						style={{
+							position: "absolute",
+							top: "-6px",
+							right: "-6px",
+							zIndex: 1,
+						}}
+					>
+						<Tooltip
+							isVisible={isWarningTooltipVisible}
+							isContrast
+							placement="bottom"
+							triggerEl={
+								<div
+									onClick={handleWarningClick}
+									style={{
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "center",
+										cursor: "pointer",
+										backgroundColor: "var(--color-gray-00, #fff)",
+										borderRadius: "50%",
+										padding: "3px",
+										border: "2px solid var(--color-yellow-60, #f0ad4e)",
+										boxShadow: "0 1px 3px rgba(0, 0, 0, 0.2)",
+									}}
+								>
+									<Icon.AlertTriangle
+										style={{
+											color: "var(--color-yellow-60, #f0ad4e)",
+											width: "12px",
+											height: "12px",
+										}}
+									/>
+								</div>
+							}
+						>
+							<div style={{ maxWidth: "15em" }}>
+								{getWarningMessage()}. Click to learn more about this issue.
+							</div>
+						</Tooltip>
+					</div>
+				)}
+			</div>
 		</div>
 	)
 }

--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -13,6 +13,107 @@ import { wallet, fetchBalances, type MappedBalances } from "../util/wallet"
 const signTransaction = wallet.signTransaction.bind(wallet)
 
 /**
+ * Each wallet can have different behaviors for `getAddress` and `getNetwork`.
+ *
+ * - `getAddressBehavior`:
+ *   - "standard": getAddress only triggers popup when not connected (ideal behavior)
+ *   - "popup-always": getAddress triggers a popup you have to sign every time it's called, even when connected
+ *
+ * - `supportsGetNetwork`:
+ *   - true: wallet supports the getNetwork method
+ *   - false: wallet does NOT support getNetwork, will use fallback/cached values
+ *
+ * - `helpUrl` (optional):
+ *   - URL to documentation or help page for this wallet's limitations
+ */
+interface WalletBehavior {
+	getAddressBehavior: "standard" | "popup-always"
+	supportsGetNetwork: boolean
+	helpUrl?: string
+}
+
+/**
+ * Default behavior for unknown wallets
+ * Assumes popup-always to avoid unwanted popups, and assumes getNetwork is not supported
+ */
+const DEFAULT_WALLET_BEHAVIOR: WalletBehavior = {
+	getAddressBehavior: "popup-always",
+	supportsGetNetwork: false,
+}
+
+const WALLET_BEHAVIORS: Record<string, WalletBehavior> = {
+	freighter: { getAddressBehavior: "standard", supportsGetNetwork: true },
+	"hot-wallet": {
+		getAddressBehavior: "popup-always",
+		supportsGetNetwork: true,
+		helpUrl: "https://github.com/hot-dao/hot-sdk-js/issues/6",
+	},
+	hana: { getAddressBehavior: "standard", supportsGetNetwork: false },
+	lobstr: {
+		getAddressBehavior: "popup-always",
+		supportsGetNetwork: false,
+		helpUrl: "https://github.com/Lobstrco/lobstr-browser-extension/issues/2",
+	},
+	albedo: {
+		getAddressBehavior: "popup-always",
+		supportsGetNetwork: false,
+		helpUrl: "https://github.com/stellar-expert/albedo/issues/104",
+	},
+	xbull: {
+		getAddressBehavior: "standard",
+		supportsGetNetwork: false,
+		helpUrl: "https://github.com/Creit-Tech/xBull-Wallet-Connect/issues/4",
+	},
+	rabet: {
+		getAddressBehavior: "standard",
+		supportsGetNetwork: false,
+		helpUrl: "https://github.com/rabetofficial/rabet-extension/issues/14",
+	},
+	klever: { getAddressBehavior: "popup-always", supportsGetNetwork: true },
+}
+
+/**
+ * Get the behavior configuration for a specific wallet
+ */
+function getWalletBehavior(walletId: string): WalletBehavior {
+	return WALLET_BEHAVIORS[walletId] ?? DEFAULT_WALLET_BEHAVIOR
+}
+
+/**
+ * Wallet warning information exposed to components
+ */
+export interface WalletWarnings {
+	hasWarnings: boolean
+	popupAlways: boolean
+	noGetNetworkSupport: boolean
+	helpUrl?: string
+}
+
+/**
+ * Get warnings for a specific wallet
+ */
+function getWalletWarnings(walletId: string | null): WalletWarnings {
+	if (!walletId) {
+		return {
+			hasWarnings: false,
+			popupAlways: false,
+			noGetNetworkSupport: false,
+		}
+	}
+
+	const behavior = getWalletBehavior(walletId)
+	const popupAlways = behavior.getAddressBehavior === "popup-always"
+	const noGetNetworkSupport = !behavior.supportsGetNetwork
+
+	return {
+		hasWarnings: popupAlways || noGetNetworkSupport,
+		popupAlways,
+		noGetNetworkSupport,
+		helpUrl: behavior.helpUrl,
+	}
+}
+
+/**
  * A good-enough implementation of deepEqual.
  *
  * Used in this file to compare MappedBalances.
@@ -42,22 +143,30 @@ export interface WalletContextType {
 	networkPassphrase?: string
 	signTransaction: typeof wallet.signTransaction
 	updateBalances: () => Promise<void>
+	walletWarnings: WalletWarnings
 }
 
 const POLL_INTERVAL = 1000
 
-export const WalletContext = createContext<WalletContextType>({
-	isPending: true,
-	balances: {},
-	updateBalances: async () => {},
-	signTransaction,
-})
+export const WalletContext = // @ts-ignore
+	createContext<WalletContextType>({
+		isPending: true,
+		balances: {},
+		updateBalances: async () => {},
+		signTransaction,
+		walletWarnings: {
+			hasWarnings: false,
+			popupAlways: false,
+			noGetNetworkSupport: false,
+		},
+	})
 
 export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
 	const [balances, setBalances] = useState<MappedBalances>({})
 	const [address, setAddress] = useState<string>()
 	const [network, setNetwork] = useState<string>()
 	const [networkPassphrase, setNetworkPassphrase] = useState<string>()
+	const [walletId, setWalletId] = useState<string | null>(null)
 	const [isPending, startTransition] = useTransition()
 	const popupLock = useRef(false)
 
@@ -66,6 +175,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
 		setNetwork(undefined)
 		setNetworkPassphrase(undefined)
 		setBalances({})
+		setWalletId(null)
 		storage.setItem("walletId", "")
 		storage.setItem("walletAddress", "")
 		storage.setItem("walletNetwork", "")
@@ -89,14 +199,58 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
 		void updateBalances()
 	}, [updateBalances])
 
+	/**
+	 * Fetches the address from the wallet, respecting wallet-specific behaviors.
+	 * For "popup-always" wallets: Never calls getAddress more than once.
+	 */
+	const fetchAddress = async (
+		walletId: string,
+		cachedAddress: string | null,
+	): Promise<{ address: string }> => {
+		const behavior = getWalletBehavior(walletId)
+
+		if (behavior.getAddressBehavior === "popup-always") {
+			if (cachedAddress) {
+				return { address: cachedAddress }
+			}
+		}
+
+		return wallet.getAddress()
+	}
+
+	/**
+	 * Fetches the network from the wallet, respecting wallet-specific behaviors.
+	 * For wallets that don't support getNetwork, returns cached values or defaults.
+	 */
+	const fetchNetwork = async (
+		walletId: string,
+		cachedNetwork: string | null,
+		cachedPassphrase: string | null,
+	): Promise<{ network: string; networkPassphrase: string }> => {
+		const behavior = getWalletBehavior(walletId)
+
+		if (!behavior.supportsGetNetwork) {
+			return {
+				network: cachedNetwork ?? "testnet",
+				networkPassphrase:
+					cachedPassphrase ?? "Test SDF Network ; September 2015",
+			}
+		}
+
+		return wallet.getNetwork()
+	}
+
 	const updateCurrentWalletState = async () => {
 		// There is no way, with StellarWalletsKit, to check if the wallet is
 		// installed/connected/authorized. We need to manage that on our side by
 		// checking our storage item.
-		const walletId = storage.getItem("walletId")
+		const storedWalletId = storage.getItem("walletId")
 		const walletNetwork = storage.getItem("walletNetwork")
 		const walletAddr = storage.getItem("walletAddress")
 		const passphrase = storage.getItem("networkPassphrase")
+
+		// Update walletId state for warnings
+		setWalletId(storedWalletId)
 
 		if (
 			!address &&
@@ -109,32 +263,36 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
 			setNetworkPassphrase(passphrase)
 		}
 
-		if (!walletId) {
+		if (!storedWalletId) {
 			nullify()
 		} else {
 			if (popupLock.current) return
-			// If our storage item is there, then we try to get the user's address &
-			// network from their wallet. Note: `getAddress` MAY open their wallet
-			// extension, depending on which wallet they select!
+
 			try {
 				popupLock.current = true
-				wallet.setWallet(walletId)
-				if (walletId !== "freighter" && walletAddr !== null) return
-				const [a, n] = await Promise.all([
-					wallet.getAddress(),
-					wallet.getNetwork(),
+				wallet.setWallet(storedWalletId)
+
+				const [addressResult, networkResult] = await Promise.all([
+					fetchAddress(storedWalletId, walletAddr),
+					fetchNetwork(storedWalletId, walletNetwork, passphrase),
 				])
 
-				if (!a.address) storage.setItem("walletId", "")
+				if (!addressResult.address) {
+					storage.setItem("walletId", "")
+					return
+				}
+
 				if (
-					a.address !== address ||
-					n.network !== network ||
-					n.networkPassphrase !== networkPassphrase
+					addressResult.address !== address ||
+					networkResult.network !== network ||
+					networkResult.networkPassphrase !== networkPassphrase
 				) {
-					storage.setItem("walletAddress", a.address)
-					setAddress(a.address)
-					setNetwork(n.network)
-					setNetworkPassphrase(n.networkPassphrase)
+					storage.setItem("walletAddress", addressResult.address)
+					storage.setItem("walletNetwork", networkResult.network)
+					storage.setItem("networkPassphrase", networkResult.networkPassphrase)
+					setAddress(addressResult.address)
+					setNetwork(networkResult.network)
+					setNetworkPassphrase(networkResult.networkPassphrase)
 				}
 			} catch (e) {
 				// If `getNetwork` or `getAddress` throw errors... sign the user out???
@@ -181,6 +339,9 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
 		}
 	}, []) // eslint-disable-line react-hooks/exhaustive-deps -- it SHOULD only run once per component mount
 
+	// Get wallet warnings based on current wallet
+	const walletWarnings = useMemo(() => getWalletWarnings(walletId), [walletId])
+
 	const contextValue = useMemo(
 		() => ({
 			address,
@@ -190,8 +351,17 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }) => {
 			updateBalances,
 			isPending,
 			signTransaction,
+			walletWarnings,
 		}),
-		[address, network, networkPassphrase, balances, updateBalances, isPending],
+		[
+			address,
+			network,
+			networkPassphrase,
+			balances,
+			updateBalances,
+			isPending,
+			walletWarnings,
+		],
 	)
 
 	return <WalletContext value={contextValue}>{children}</WalletContext>

--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -86,6 +86,7 @@ export interface WalletWarnings {
 	hasWarnings: boolean
 	popupAlways: boolean
 	noGetNetworkSupport: boolean
+	messages: string[]
 	helpUrl?: string
 }
 
@@ -98,6 +99,7 @@ function getWalletWarnings(walletId: string | null): WalletWarnings {
 			hasWarnings: false,
 			popupAlways: false,
 			noGetNetworkSupport: false,
+			messages: [],
 		}
 	}
 
@@ -105,10 +107,19 @@ function getWalletWarnings(walletId: string | null): WalletWarnings {
 	const popupAlways = behavior.getAddressBehavior === "popup-always"
 	const noGetNetworkSupport = !behavior.supportsGetNetwork
 
+	const messages: string[] = []
+	if (popupAlways) {
+		messages.push("This wallet triggers a popup on every interaction")
+	}
+	if (noGetNetworkSupport) {
+		messages.push("This wallet doesn't support network detection")
+	}
+
 	return {
 		hasWarnings: popupAlways || noGetNetworkSupport,
 		popupAlways,
 		noGetNetworkSupport,
+		messages,
 		helpUrl: behavior.helpUrl,
 	}
 }
@@ -158,6 +169,7 @@ export const WalletContext = // @ts-ignore
 			hasWarnings: false,
 			popupAlways: false,
 			noGetNetworkSupport: false,
+			messages: [],
 		},
 	})
 

--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -109,10 +109,10 @@ function getWalletWarnings(walletId: string | null): WalletWarnings {
 
 	const messages: string[] = []
 	if (popupAlways) {
-		messages.push("This wallet triggers a popup on every interaction")
+		messages.push("This wallet triggers a popup on every interaction. ")
 	}
 	if (noGetNetworkSupport) {
-		messages.push("This wallet doesn't support network detection")
+		messages.push("This wallet doesn't support network detection. ")
 	}
 
 	return {

--- a/src/util/wallet.ts
+++ b/src/util/wallet.ts
@@ -2,7 +2,7 @@ import {
 	type ISupportedWallet,
 	StellarWalletsKit,
 	type WalletNetwork,
-	sep43Modules,
+	allowAllModules,
 } from "@creit.tech/stellar-wallets-kit"
 import { Horizon } from "@stellar/stellar-sdk"
 import { networkPassphrase, stellarNetwork } from "../contracts/util"
@@ -10,7 +10,7 @@ import storage from "./storage"
 
 const kit: StellarWalletsKit = new StellarWalletsKit({
 	network: networkPassphrase as WalletNetwork,
-	modules: sep43Modules(),
+	modules: allowAllModules(),
 })
 
 export const connectWallet = async () => {
@@ -51,6 +51,9 @@ export const connectWallet = async () => {
 export const disconnectWallet = async () => {
 	await kit.disconnect()
 	storage.removeItem("walletId")
+	storage.removeItem("walletAddress")
+	storage.removeItem("walletNetwork")
+	storage.removeItem("networkPassphrase")
 }
 
 function getHorizonHost(mode: string) {


### PR DESCRIPTION
DEPENDS ON #91 

Closes #93 

This PR adds a warning message on the wallet selection button for wallets that currently have integration issues with Stellar Wallets Kit. Each warning links directly to a dedicated GitHub issue created for the corresponding wallet.

Some wallets:

always trigger a popup when calling getAddress(), even if the user is already connected,
and/or do not support getNetwork().